### PR TITLE
Adds Discord webhook handler in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 node_modules/
 
 config.json
+discord-webhook-handler/discord-webhook-handler.exe

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # How to use
 
 1. `npm install` - to install deps
-2. `node server.js` - to run a server that will handle rolls.
+2. go to discord-webhook-handler and run `go build -o discord-webhook-handler.exe main.go`
+3. `node server.js` - to run a server that will handle rolls.
 You`ll need a Pixels app that will send requests from dice (I just send it to local network ip address)
-3. Create file config.json, you may rename config.example.json
+4. Create file config.json, you may rename config.example.json
 
 ## Roll20
 
@@ -19,5 +20,12 @@ You`ll need a Pixels app that will send requests from dice (I just send it to lo
 
 1. Initialize Webhook in Discord channel.
 2. Copy Webhook link and paste it in config.json
-3. For better experience insert your Discord user ID in Value field (e.g. `<@idnumber>`)
-4. Open chat, roll the die and see it pasting messages
+3. Run the server, then run discord-webhook-handler.exe
+4. For better experience insert your Discord user ID in Value field (e.g. `<@idnumber>`) in Pixels App
+5. Open chat, roll the die and see it pasting messages
+
+-> For VPN purposes you should enable app-based split tunneling and add discord-webhook-handler.exe to VPN whitelist
+This should resolve the issue with local proxy.
+-> If you use blacklist instead, make sure that the app running your server.js (e.g. VSCode) is in the list of apps that SOULD NOT have access via VPN
+
+> Note: Pixels → {No VPN REST local} →  server.js → WebSocket → discord-webhook-handler.exe → {Yes VPN REST global} →  Discord webhook

--- a/discord-webhook-handler/go.mod
+++ b/discord-webhook-handler/go.mod
@@ -1,0 +1,5 @@
+module discord_webhook_handler
+
+go 1.25.5
+
+require github.com/gorilla/websocket v1.5.3 

--- a/discord-webhook-handler/go.sum
+++ b/discord-webhook-handler/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/discord-webhook-handler/main.go
+++ b/discord-webhook-handler/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+// структура сообщения от Node.js
+type DiscordRequest struct {
+	WebhookURL string                 `json:"DISCORD_WEBHOOK_URL"`
+	Data       map[string]interface{} `json:"data"`
+	Headers    map[string]string      `json:"headers"`
+}
+
+func main() {
+	wsURL := "ws://127.0.0.1:8081/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		log.Fatalf("Ошибка подключения к WebSocket: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Println("discord-webhook-handler.exe подключен к WebSocket")
+
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("Ошибка чтения WebSocket:", err)
+			return
+		}
+
+		var req DiscordRequest
+		if err := json.Unmarshal(message, &req); err != nil {
+			log.Println("Некорректный JSON:", err)
+			continue
+		}
+
+		// сериализуем Data в JSON
+		jsonBody, err := json.Marshal(req.Data)
+		if err != nil {
+			log.Println("Ошибка сериализации JSON:", err)
+			continue
+		}
+
+		// создаём POST-запрос
+		httpReq, err := http.NewRequest("POST", req.WebhookURL, bytes.NewBuffer(jsonBody))
+		if err != nil {
+			log.Println("Ошибка создания HTTP запроса:", err)
+			continue
+		}
+
+		// добавляем заголовки
+		for key, val := range req.Headers {
+			httpReq.Header.Set(key, val)
+		}
+
+		resp, err := http.DefaultClient.Do(httpReq)
+		if err != nil {
+			log.Println("Ошибка отправки вебхука:", err)
+			continue
+		}
+		resp.Body.Close()
+
+		fmt.Println("Webhook успешно отправлен")
+	}
+}


### PR DESCRIPTION
Introduces a Go-based Discord webhook handler to improve message delivery.

This change replaces the direct calls to the Discord API with a dedicated Go application that handles sending webhooks.
The Go application connects to the Node.js server via WebSockets, receives webhook data, and then forwards it to Discord.
This aims to make it easier to handle errors and retry sending the webhooks if discord is unavailable.

Also add the executable to the .gitignore

Updates README with instructions for running the Discord webhook handler and configuring VPN settings.